### PR TITLE
Rename "e-mail" to "email"

### DIFF
--- a/email_log/locale/de/LC_MESSAGES/django.po
+++ b/email_log/locale/de/LC_MESSAGES/django.po
@@ -19,8 +19,8 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: models.py:13
-msgid "from e-mail"
-msgstr "Von E-Mail"
+msgid "from email"
+msgstr "Von EMail"
 
 #: models.py:14
 msgid "recipients"
@@ -43,9 +43,9 @@ msgid "date sent"
 msgstr "Sendedatum"
 
 #: models.py:24
-msgid "e-mail"
-msgstr "E-Mail"
+msgid "email"
+msgstr "Email"
 
 #: models.py:25
-msgid "e-mails"
-msgstr "E-Mails"
+msgid "emails"
+msgstr "Emails"

--- a/email_log/locale/en/LC_MESSAGES/django.po
+++ b/email_log/locale/en/LC_MESSAGES/django.po
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: models.py:13
-msgid "from e-mail"
+msgid "from email"
 msgstr ""
 
 #: models.py:14
@@ -42,9 +42,9 @@ msgid "date sent"
 msgstr ""
 
 #: models.py:24
-msgid "e-mail"
+msgid "email"
 msgstr ""
 
 #: models.py:25
-msgid "e-mails"
+msgid "emails"
 msgstr ""

--- a/email_log/locale/pt_BR/LC_MESSAGES/django.po
+++ b/email_log/locale/pt_BR/LC_MESSAGES/django.po
@@ -20,7 +20,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: models.py:13
-msgid "from e-mail"
+msgid "from email"
 msgstr "Remetente"
 
 #: models.py:14
@@ -44,9 +44,9 @@ msgid "date sent"
 msgstr "Data de envio"
 
 #: models.py:24
-msgid "e-mail"
-msgstr "e-mail"
+msgid "email"
+msgstr "email"
 
 #: models.py:25
-msgid "e-mails"
-msgstr "e-mails"
+msgid "emails"
+msgstr "emails"

--- a/email_log/migrations/0002_email.py
+++ b/email_log/migrations/0002_email.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('email_log', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name='email',
+            options={'ordering': ('-date_sent',), 'verbose_name_plural': 'emails', 'verbose_name': 'email'},
+        ),
+        migrations.AlterField(
+            model_name='email',
+            name='from_email',
+            field=models.TextField(verbose_name='from email'),
+        ),
+    ]

--- a/email_log/models.py
+++ b/email_log/models.py
@@ -10,7 +10,7 @@ class Email(models.Model):
 
     """Model to store outgoing email information"""
 
-    from_email = models.TextField(_("from e-mail"))
+    from_email = models.TextField(_("from email"))
     recipients = models.TextField(_("recipients"))
     subject = models.TextField(_("subject"))
     body = models.TextField(_("body"))
@@ -22,6 +22,6 @@ class Email(models.Model):
         return "{s.recipients}: {s.subject}".format(s=self)
 
     class Meta:
-        verbose_name = _("e-mail")
-        verbose_name_plural = _("e-mails")
+        verbose_name = _("email")
+        verbose_name_plural = _("emails")
         ordering = ('-date_sent',)


### PR DESCRIPTION
According to Google Translate, "email" seems to be preferred for German
and Portuguese, so I updated those languages as well.

This addresses issue #11.