### PR TITLE
Grant an admin permission to delete log entries

### DIFF
--- a/email_log/admin.py
+++ b/email_log/admin.py
@@ -12,7 +12,9 @@ class EmailAdmin(admin.ModelAdmin):
     exclude = ['body']
 
     def has_delete_permission(self, *args, **kwargs):
-        return False
+        request = args[0]
+        user = request.user
+        return user.is_superuser
 
     def has_add_permission(self, *args, **kwargs):
         return False


### PR DESCRIPTION
Is there any good reason an admin should not be able to manage the log file entries? I mean Ic an do it using pgadmin if need be. Seems an oversight.