### PR TITLE
Filter what to log or not by subject and add err message column to log also the error

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,3 +7,4 @@ Authors and contributors to django-email-log (listed alphabetically):
 - Rodrigo Deodoro <http://deodoro.org>
 - Serafeim Papastefanos <https://www.spapas.net>
 - Trey Hunner <http://treyhunner.com>
+- Aladdin-97 <https://github.com/Aladdin-97>

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 CHANGES
 =======
+1.5.0 (2023-07-15)
+-------------------
+- Added the possibiltity to filter by subject what log on db and not
+- Added the column err_msg in order to see from the admin the error messages
 
 1.4.0 (2023-04-06)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,11 @@ django-email-log
    :alt: Codecov
 
 Django email backend that logs all sent emails to a database using a Django model.
-
+It is possibile to filter by subject what to log on or not also by setting this:
+```
+# LOG ONLY DEFINED SUBJECT, SUBJECT CAN BE PARTIAL TOO
+EMAIL_LOG_SUBJECTS = ["Subject 1", "Subject 2"]
+```
 This app works with Django 2.2 to 4.2
 
 This app requires Python 3.7+.

--- a/email_log/admin.py
+++ b/email_log/admin.py
@@ -39,6 +39,7 @@ class EmailAdmin(admin.ModelAdmin):
         "html_message",
         "date_sent",
         "ok",
+        "err_msg"
     ]
     inlines = [
         AttachmentInline,

--- a/email_log/backends.py
+++ b/email_log/backends.py
@@ -59,7 +59,7 @@ class EmailBackend(BaseEmailBackend):
                 status = True
                 err_msg = ""
             except Exception as e:
-                logging.critical(f"Error mail log {e}")
+                logging.error(f"Error while sending mail: {e}")
                 status = False
                 err_msg = ERR_TEMPLATE.format(type(e).__name__, e.args)
 

--- a/email_log/backends.py
+++ b/email_log/backends.py
@@ -64,7 +64,7 @@ class EmailBackend(BaseEmailBackend):
                 err_msg = ERR_TEMPLATE.format(type(e).__name__, e.args)
 
             if email:
-                email.status = status
+                email.ok = status
                 email.err_msg = err_msg
                 try:
                     email.save()

--- a/email_log/conf.py
+++ b/email_log/conf.py
@@ -9,6 +9,7 @@ class Settings:
         EMAIL_LOG_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
         EMAIL_LOG_SAVE_ATTACHMENTS = False
         EMAIL_LOG_ATTACHMENTS_PATH = ""
+        EMAIL_LOG_SUBJECTS = []
 
     def __init__(self):
         self.defaults = Settings.Default()

--- a/email_log/models.py
+++ b/email_log/models.py
@@ -17,6 +17,7 @@ class Email(models.Model):
     ok = models.BooleanField(_("ok"), default=False, db_index=True)
     date_sent = models.DateTimeField(_("date sent"), auto_now_add=True, db_index=True)
     html_message = models.TextField(_("HTML message"), blank=True)
+    err_msg = models.TextField(_("Error message"), blank=True)
 
     def __str__(self):
         return "{s.recipients}: {s.subject}".format(s=self)


### PR DESCRIPTION
Hello, 
this module is pretty good.
but sometime, it is preferable to filter what email to log or not. it become more handier.
with these edits, now it will be possibile to define which subject should be logged in:
`
EMAIL_LOG_SUBJECTS = ["subject 1", "subject 2]
`

Also now the error message while sending will be visibile (if any) on the admin page.
which is prettier and direct, instead of searching in the server logs.

![image](https://github.com/treyhunner/django-email-log/assets/26227482/21d681da-0f64-421a-a540-730bcdf9e78e)

Let me know what do you think.