### PR TITLE
Add HTML message preview using iframe

### DIFF
--- a/email_log/admin.py
+++ b/email_log/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
 from django.template.defaultfilters import linebreaksbr
+from django.utils.html import format_html
 from .models import Attachment, Email
 
 
@@ -36,7 +37,7 @@ class EmailAdmin(admin.ModelAdmin):
         "recipients",
         "subject",
         "body_formatted",
-        "html_message",
+        "html_message_preview",
         "date_sent",
         "ok",
     ]
@@ -44,13 +45,24 @@ class EmailAdmin(admin.ModelAdmin):
         AttachmentInline,
     ]
     search_fields = ["subject", "body", "recipients"]
-    exclude = ["body"]
+    exclude = ["body", "html_message"]
 
     def has_delete_permission(self, *args, **kwargs):
         return False
 
     def has_add_permission(self, *args, **kwargs):
         return False
+
+    def html_message_preview(self, obj):
+        if obj.html_message:
+            return format_html(
+                '<iframe srcdoc="{}" width="800px" height="600px"></iframe>',
+                obj.html_message
+            )
+        else:
+            return "No HTML content"
+
+    html_message_preview.short_description = "HTML message"
 
     def body_formatted(self, obj):
         return linebreaksbr(obj.body)


### PR DESCRIPTION
The current preview of HTML messages is difficult to read since they are displayed as plain text strings. The proposed PR addresses this by rendering the HTML within an iframe, allowing the messages to be displayed as they would appear in the recipient’s mailbox.