### PR TITLE
Grant admin delete permission

### DIFF
--- a/email_log/admin.py
+++ b/email_log/admin.py
@@ -60,8 +60,8 @@ class EmailAdmin(admin.ModelAdmin):
     ]
     exclude = ["body", "extra_headers"]
 
-    def has_delete_permission(self, *args, **kwargs):
-        return False
+    def has_delete_permission(self, request, *args, **kwargs):
+        return request.user.is_superuser
 
     def has_add_permission(self, *args, **kwargs):
         return False


### PR DESCRIPTION
Rebased #25 onto current `main` branch.

Allow superusers to delete email log entries.

I also updated and added a test for this.

Hat tip: @bernd-wechner